### PR TITLE
Add API_URL constant

### DIFF
--- a/src/Components/Jobs/Jobs.js
+++ b/src/Components/Jobs/Jobs.js
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { config } from '../../Constants';
 import axios from 'axios';
 import JobsListItem from '../JobsListItem/JobsListItem';
 import Spinner from 'react-bootstrap/Spinner';
@@ -10,11 +11,8 @@ function Jobs({ username }) {
 	const [error, setError] = useState(false);
 
 	function getUser() {
-		// Production URL
-		//const url = `https://sei-trakr.herokuapp.com/api/user/${username}`;
-
-		//Local testing URL
-		const url = `http://localhost:8000/api/user/${username}`;
+		// Get API URL from config
+		const url = `${config.API_URL}/user/${username}`;
 		axios
 			.get(url)
 			.then((res) => {

--- a/src/Constants.js
+++ b/src/Constants.js
@@ -1,0 +1,10 @@
+// Constants.js
+const prod = {
+	API_URL: 'https://sei-trakr.herokuapp.com/api',
+};
+
+const dev = {
+	API_URL: 'http://localhost:8000/api',
+};
+
+export const config = process.env.NODE_ENV === 'development' ? dev : prod;


### PR DESCRIPTION
I added a Constants.js file in the src folder.

```js
// Constants.js
const prod = {
	API_URL: 'https://sei-trakr.herokuapp.com/api',
};

const dev = {
	API_URL: 'http://localhost:8000/api',
};

export const config = process.env.NODE_ENV === 'development' ? dev : prod;
```

This will set API_URL to use our localhost in development and when we deploy frontend to netlify it will automatically switch to use our heroku backend API so we don't have to change any URLS back and forth.

To use this in your component add:
```js
// Import the config object from Constants
import { config } from '../../Constants';

// use config.API_URL to get the base URL and then add whatever endpoint to the base URL. 
const url = `${config.API_URL}/user/${username}`;
```